### PR TITLE
Update gunicorn version to avoid vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.12.2
 Jinja2==2.7.1
 Werkzeug==0.9.4
-gunicorn==18.0
+gunicorn==19.5.0
 dropbox==8.6.0
 rq==0.10.0


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2018-1000164.